### PR TITLE
Changed default charset from "UTF8" to "UTF-8" to respect standards

### DIFF
--- a/lib/Email/Outlook/Message.pm
+++ b/lib/Email/Outlook/Message.pm
@@ -372,7 +372,7 @@ sub _create_mime_plain_body {
   return Email::MIME->create(
     attributes => {
       content_type => "text/plain",
-      charset => "UTF8",
+      charset => "UTF-8",
       disposition => "inline",
       encoding => "8bit",
     },


### PR DESCRIPTION
https://tools.ietf.org/html/rfc3629#section-8 specifies the charset-parameter in MIME to be "UTF-8" instead of "UTF8". 

Although most clients will also support the version without a hyphen, they are not obliged to, so it is safer to follow the standards.