### PR TITLE
Fix raw writing instead of utf8

### DIFF
--- a/script/msgconvert
+++ b/script/msgconvert
@@ -53,9 +53,8 @@ foreach my $file (@ARGV) {
     if ($outfile eq '-') {
         open OUT, ">&", STDOUT;
     } else {
-        open OUT, ">:utf8", $outfile or die "Can't open $outfile for writing: $!";
+        open OUT, ">", $outfile or die "Can't open $outfile for writing: $!";
     }
-    binmode(OUT, ":utf8");
     print OUT $mail->as_string;
     close OUT;
   }


### PR DESCRIPTION
Actually, writing utf8 is wrong; msgconvert shouldn't convert during writing.
Together with https://github.com/rjbs/Email-MIME/pull/36 , I finally have msg files converted to eml without unicode problems.