### PR TITLE
Uncompressed RTF fix

### DIFF
--- a/lib/Email/Outlook/Message.pm
+++ b/lib/Email/Outlook/Message.pm
@@ -441,7 +441,7 @@ sub _create_mime_rtf_body {
     }
     $buffer = substr $buffer, length $BASE_BUFFER;
   } elsif ($magic == $MAGIC_UNCOMPRESSED_RTF) {
-    $buffer = substr $data, length $BASE_BUFFER;
+    $buffer = substr $data, 16;
   } else {
     carp "Incorrect magic number in RTF body.\n";
   }


### PR DESCRIPTION
Fix bug with extracting uncompressed RTF content - when this header is encountered, the actual RTF content is everything past the 16 byte header (`$BASE_BUFFER` is not used in this case).
This is based on some actual emails I've encountered with uncompressed RTF bodies as well as the format details in http://www.freeutils.net/source/jtnef/rtfcompressed.jsp and the JTNEF implemention linked therein.