### PR TITLE
msgconvert: Fix mbox separators

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,6 +12,7 @@ my $build = Module::Build->new (
     'POSIX' => '0',
     # Others - Not versioned
     'Carp' => '0',
+    'Email::Address' => '0',
     'Encode' => '0',
     'Getopt::Long' => '0',
     'IO::String' => '0',

--- a/script/msgconvert
+++ b/script/msgconvert
@@ -5,6 +5,7 @@
 # Convert .MSG files (made by Outlook (Express)) to multipart MIME messages.
 #
 
+use Email::Address;
 use Email::Outlook::Message;
 use Email::Sender::Transport::Mbox;
 use Getopt::Long;
@@ -44,7 +45,10 @@ foreach my $file (@ARGV) {
   my $msg = new Email::Outlook::Message($file, $verbose);
   my $mail = $msg->to_email_mime;
   if ($using_mbox) {
-    $transport->send($mail->as_string, { from => $mail->header('From') || '' });
+    my $from;
+    my @from_addr = Email::Address->parse($mail->header('From'));
+    $from = $from_addr[0]->address if @from_addr;
+    $transport->send($mail->as_string, { from => $from || '' });
   } else {
     if (!$using_outfile) {
         my $basename = fileparse($file, qr/\.msg/i);


### PR DESCRIPTION
The mbox "From " separator line should use just the email address,
but we were using the whole content of the "From:" header.

Fixes #12