### PR TITLE
Test suite: Allow MIME headers with and without double quotes

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -18,7 +18,7 @@ my $build = Module::Build->new (
     'IO::String' => '0',
     'Pod::Usage' => '0',
     # Others - Versioned
-    'Email::MIME' => '1.949',
+    'Email::MIME' => '1.923',
     'Email::MIME::ContentType' => '1.014',
     'Email::Sender' => '1.3',
     'Email::Simple' => '2.206',

--- a/t/charset.t
+++ b/t/charset.t
@@ -20,12 +20,12 @@ is(scalar(@parts), 2, "Two sub-parts");
 
 my $text = $parts[0];
 like($text->content_type, qr{^text/plain}, "Content type should be multipart/alternative");
-like($text->content_type, qr{; charset=CP1252}, "charset should be CP1252");
+like($text->content_type, qr{; charset="?CP1252"?}, "charset should be CP1252");
 is($text->header("Content-Disposition"), "inline", "Testing content disposition");
 is($text->body, "This email contains an email\x85 Email-ception!!!\n\n", "Testing body");
 is(scalar($text->subparts), 0, "No sub-parts");
 my $html = $parts[1];
 like($html->content_type, qr{^text/html}, "Content type should be text/html");
-like($text->content_type, qr{; charset=CP1252}, "charset should be CP1252");
+like($text->content_type, qr{; charset="?CP1252"?}, "charset should be CP1252");
 is($html->header("Content-Disposition"), "inline", "Testing content disposition");
 is(scalar($html->subparts), 0, "No sub-parts");

--- a/t/internals.t
+++ b/t/internals.t
@@ -63,7 +63,7 @@ sub test_to_email_mime_with_plain_part {
   ok(defined $m);
   ok(($m->parts) == 1);
   is($m->body, "plain");
-  is($m->content_type, "text/plain; charset=CP1252");
+  like($m->content_type, qr{^text/plain; charset="?CP1252"?$});
 }
 
 sub test_to_email_mime_with_html_part {
@@ -74,7 +74,7 @@ sub test_to_email_mime_with_html_part {
   ok(defined $m);
   ok(($m->parts) == 1);
   is($m->body, "html");
-  is($m->content_type, "text/html; charset=CP1252");
+  like($m->content_type, qr{^text/html; charset="?CP1252"?$});
 }
 
 sub test_to_email_mime_with_two_parts {

--- a/t/plain_jpeg_attached.t
+++ b/t/plain_jpeg_attached.t
@@ -35,6 +35,6 @@ is(scalar($rtf->subparts), 0, "No sub-parts");
 
 my $jpg = $parts[1];
 like($jpg->content_type, qr{^image/jpeg}, "Content type should be image/jpeg");
-is($jpg->header("Content-Disposition"), "attachment; filename=test.jpg", "Testing content disposition");
+like($jpg->header("Content-Disposition"), qr{^attachment; filename="?test.jpg"?$}, "Testing content disposition");
 is(scalar($jpg->subparts), 0, "No sub-parts");
 is(length($jpg->body), 7681, "Correct jpeg size");


### PR DESCRIPTION
This helps to support both, Email::MIME versions before and after 1.949 and does allow lower the requirement for the most recent Email::MIME version again.

That patch comes from the Debian package libemail-outlook-message-perl and will be applied there in the upload of 0.920-1: https://salsa.debian.org/perl-team/modules/packages/libemail-outlook-message-perl/-/blob/master/debian/patches/fix-test-failures.patch