### PR TITLE
Feature/caching dependencies

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Setup Perl environment
         uses: shogo82148/actions-setup-perl@v1.6.2
 
-      - name: Restore dependencies from cache
+      - name: Restore install dependencies from cache
         uses: actions/cache@v1.0.3
         with:
-          path: /usr/local/lib/perl5
+          path: /opt/hostedtoolcache/perl
           key: builddeps-${{ hashFiles('**/Build.PL') }}
           restore-keys: |
             builddeps-

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,9 +3,9 @@ name: CI
 # Trigger the workflow on push or pull request events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [master, feature/caching-dependencies]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   # This workflow contains a single job called "build"
@@ -20,9 +20,17 @@ jobs:
 
       - name: Setup Perl environment
         uses: shogo82148/actions-setup-perl@v1.6.2
-      
+
+      - name: Restore dependencies from cache
+        uses: actions/cache@v1.0.3
+        with:
+          path: /usr/local/lib/perl5
+          key: builddeps-${{ hashFiles('**/Build.PL') }}
+          restore-keys: |
+            builddeps-
+
       - name: Install dependencies
         run: cpanm --installdeps .
-        
+
       - name: Run tests
         run: prove -lv t

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1.6.2
 
       - name: Restore install dependencies from cache
-        uses: actions/cache@v1.0.3
+        uses: actions/cache@v2
         with:
           path: /opt/hostedtoolcache/perl
           key: builddeps-${{ hashFiles('**/Build.PL') }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,9 +3,9 @@ name: CI
 # Trigger the workflow on push or pull request events but only for the master branch
 on:
   push:
-    branches: [master, feature/caching-dependencies]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Hi, I added a simple but settings which workflow caches install dependencies.

## Issue
https://github.com/mvz/email-outlook-message-perl/issues/23

## NOTE
Caching dependencies reduced the workflow time from 2m26s to 30s.
https://github.com/tsubasaogawa/email-outlook-message-perl/actions/runs/273833428
https://github.com/tsubasaogawa/email-outlook-message-perl/actions/runs/273836489

Workflow starts to use new cache when we rewrote `Build.PL` including versions of dependencies.
In the future, it looks better to replace Build.PL with module's lock file (ex. cpanfile.snapshot) in `hashFiles`.