### PR TITLE
Use latest version of actions-setup-perl action

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Perl environment
-        uses: shogo82148/actions-setup-perl@v1.6.2
+        uses: shogo82148/actions-setup-perl@v1.8.3
 
       - name: Restore install dependencies from cache
         uses: actions/cache@v2


### PR DESCRIPTION
This should fix errors in the perl setup step due to deprecation of the add-path command.