### PR TITLE
Make full structure test work with different file name quoting

### DIFF
--- a/t/files/plain_jpeg_attached.eml
+++ b/t/files/plain_jpeg_attached.eml
@@ -57,7 +57,7 @@ cmRccGxhaW5cZGVmdGFiMzYwIFxmMFxmczIwIHRlc3RccGFyCg19
 --15987272481.a3dF7.966347
 Content-ID: 
 Content-Type: image/jpeg; name=test.jpg
-Content-Disposition: attachment; filename=test.jpg
+Content-Disposition: attachment; filename="test.jpg"
 Content-Transfer-Encoding: base64
 
 /9j/4AAQSkZJRgABAQEASABIAAD/4QAWRXhpZgAATU0AKgAAAAgAAAAAAAD//gATQ3JlYXRlZCB3

--- a/t/full_structure.t
+++ b/t/full_structure.t
@@ -61,6 +61,7 @@ sub get_headers {
   my @arr = map {
     my @h = map { $_ =~ s/\s\s*/ /sg; $_ } sort $m->header($_);
     @h = map { sanitize_content_type($_) } @h if lc $_ eq 'content-type';
+    @h = map { sanitize_content_disposition($_) } @h if lc $_ eq 'content-disposition';
     $_ . ": " . join "\n", @h;
   } @names;
   return \@arr;
@@ -73,6 +74,12 @@ sub sanitize_content_type {
   delete $at->{boundary};
   $at->{charset} = "us-ascii" unless exists $at->{charset};
   return join("; ", "$ct->{discrete}/$ct->{composite}",
-    map("$_=\"$ct->{attributes}->{$_}\"",
-      sort keys %{$ct->{attributes}}));
+    map("$_=\"$at->{$_}\"", sort keys %$at));
+}
+
+sub sanitize_content_disposition {
+  my $s = shift;
+  my $cd = parse_content_disposition($s);
+  my $at = $cd->{attributes};
+  return join("; ", map("$_=\"$at->{$_}\"", sort keys %$at));
 }


### PR DESCRIPTION
Older versions of Email::MIME seem to always include quotation marks around the filename in Content-Disposition. This makes the `full_structure` test fail. This change sanitizes the Content-Disposition header so this difference is ignored.

Fixes #36.
