### PR TITLE
Major perf improvement with large #s of addresses and small block data

### DIFF
--- a/lib/Email/Outlook/Message.pm
+++ b/lib/Email/Outlook/Message.pm
@@ -66,7 +66,6 @@ use Email::MIME::Creator;
 use Email::Outlook::Message::AddressInfo;
 use Email::Outlook::Message::Attachment;
 use Carp;
-use List::Util qw(first);
 use base 'Email::Outlook::Message::Base';
 
 our $skipheaders = {

--- a/lib/Email/Outlook/Message.pm
+++ b/lib/Email/Outlook/Message.pm
@@ -66,6 +66,7 @@ use Email::MIME::Creator;
 use Email::Outlook::Message::AddressInfo;
 use Email::Outlook::Message::Attachment;
 use Carp;
+use List::Util qw(first);
 use base 'Email::Outlook::Message::Base';
 
 our $skipheaders = {
@@ -105,7 +106,6 @@ our $MAP_CODEPAGE = {
   20127 => 'US-ASCII',
   20866 => 'KOI8-R',
   28591 => 'ISO-8859-1',
-  28592 => 'ISO-8859-2',
   65001 => 'UTF-8',
 };
 
@@ -136,7 +136,7 @@ sub _empty_new {
   my $class = shift;
 
   return bless {
-    ADDRESSES => [], ATTACHMENTS => [], FROM_ADDR_TYPE => "",
+    ADDRESSES => {}, ATTACHMENTS => [], FROM_ADDR_TYPE => "",
     VERBOSE => 0, EMBEDDED => 1
   }, $class;
 }
@@ -242,7 +242,7 @@ sub _process_address {
   my $addr_info = Email::Outlook::Message::AddressInfo->new($pps,
     $self->{VERBOSE});
 
-  push @{$self->{ADDRESSES}}, $addr_info;
+  $self->{ADDRESSES}->{$addr_info->name} = $addr_info->display_address;
   return;
 }
 
@@ -358,14 +358,7 @@ sub _expand_address_list {
 sub _find_name_in_addresspool {
   my ($self, $name) = @_;
 
-  my $addresspool = $self->{ADDRESSES};
-
-  foreach my $address (@{$addresspool}) {
-    if ($name eq $address->name) {
-      return $address->display_address;
-    }
-  }
-  return;
+  return $self->{ADDRESSES}->{$name};
 }
 
 # TODO: Don't really want to need this!

--- a/lib/Email/Outlook/Message/AddressInfo.pm
+++ b/lib/Email/Outlook/Message/AddressInfo.pm
@@ -63,10 +63,10 @@ sub _process_subdirectory {
   return;
 }
 
-sub name { my $self = shift; return $self->property('NAME') }
-sub address_type { my $self = shift; return $self->property('TYPE') }
-sub address { my $self = shift; return $self->property('ADDRESS') }
-sub smtp_address { my $self = shift; return $self->property('SMTPADDRESS') }
+sub name { $_[0]->property('NAME') }
+sub address_type { $_[0]->property('TYPE') }
+sub address { $_[0]->property('ADDRESS') }
+sub smtp_address { $_[0]->property('SMTPADDRESS') }
 
 sub display_address {
   my $self = shift;


### PR DESCRIPTION
I have a customer message with 1100 addresses and tons of other small block data that takes 9.5 minutes to parse, but after optimizing both this module and OLE::Storage_lite (PR created for that project too), the time is down to < 4 seconds
There are a few fixes here
1) eliminate linear address scan and use hash lookup instead
2) cache the utf16 decoder as looking up every time is slow
3) optimize methods called countless times - I had one at 4 billion calls!
