### PR TITLE
header_str_set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pm_to_blib
 /Makefile.PL
 /tmp
 /docs
+.vscode

--- a/lib/Email/Outlook/Message.pm
+++ b/lib/Email/Outlook/Message.pm
@@ -318,7 +318,7 @@ sub _AddHeaderField {
 
   #my $oldvalue = $mime->header($fieldname);
   #return if $oldvalue;
-  $mime->header_set($fieldname, $value) if $value;
+  $mime->header_str_set($fieldname, $value) if $value;
   return;
 }
 


### PR DESCRIPTION
Hi there, when I checking in Email::MIME::Header

=head1 DESCRIPTION

This object behaves like a standard Email::Simple header, with the following
changes:

=for :list
* the C<header> method automatically decodes encoded headers if possible
* the C<header_as_obj> method returns an object representation of the header value
* the C<header_raw> method returns the raw header; (read only for now)
* stringification uses C<header_raw> rather than C<header>

Note that C<header_set> does not do encoding for you, and expects an
encoded header.  Thus, C<header_set> round-trips with C<header_raw>,
not C<header>!  Be sure to properly encode your headers with
C<Encode::encode('MIME-Header', $value)> before passing them to
C<header_set>.  And be sure to use minimal version 2.83 of Encode
module due to L<bugs in MIME-Header|Encode::MIME::Header/BUGS>.

Alternately, if you have Unicode (character) strings to set in headers, use the
C<header_str_set> method.

=cut